### PR TITLE
Pluck modal out of context, avoid parent z-index

### DIFF
--- a/vendor/assets/javascripts/jquery.modal.js
+++ b/vendor/assets/javascripts/jquery.modal.js
@@ -18,6 +18,7 @@
       if (/^#/.test(target)) {
         this.$elm = $(target);
         if (this.$elm.length !== 1) return null;
+        this.$body.append(this.$elm);
         this.open();
       //AJAX
       } else {


### PR DESCRIPTION
This allows a modal to be placed in a view template nested inside a
parent element that also has a z-index set. Without this fix, the modal
does not show above the overlay as it inherits it's parent's z-index,
regardless of what is actually set on the modal element
