### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###Currently I moved to angular-js for all my web applications. Because of that I do not maintain this project any more. It would be a pleasure for me to hand this project over to an other developer. Please just send me a note or create a issue if you are the one. 
+### Currently I moved to angular-js for all my web applications. Because of that I do not maintain this project any more. It would be a pleasure for me to hand this project over to an other developer. Please just send me a note or create a issue if you are the one. 
 
 jquery-modal-rails
 ==================


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
